### PR TITLE
chore: cleanup and add release docker compose for tshot purpose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,5 @@ Dockerfile
 .gitignore
 tarpaulin-report.html
 specs/*
-service_account.json
+**/*service_account.json
 **/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 **/target
-**/.env
+**/*env
 **husni-portfolio.db**
 tarpaulin-report.html
-service_account.json
+**/*service_account.json
 **/.DS_Store
 **/local.db

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,7 +71,7 @@ tasks:
       - |
         export $(cat .env | xargs)
         export SVC_VERSION=$(cat version.json | jq --raw-output '.version')
-        cd build
+        cd build/dev
         docker compose up -d
   docker-compose-down:
     summary: Teardown docker compose
@@ -79,7 +79,7 @@ tasks:
       - |
         export $(cat .env | xargs)
         export SVC_VERSION=$(cat version.json | jq --raw-output '.version')
-        cd build
+        cd build/dev
         docker compose down
 
   tailwind-build:

--- a/build/dev/docker-compose.yml
+++ b/build/dev/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     environment:
         GOOGLE_APPLICATION_CREDENTIALS: /var/service_account.json
     env_file:
-      - "../.env"
+      - "../../.env"
     ports:
       - ${SVC_PORT}:${SVC_PORT}
     volumes:
-      - ./../service_account.json:/var/service_account.json
+      - ./../../service_account.json:/var/service_account.json

--- a/build/release/docker-compose.yml
+++ b/build/release/docker-compose.yml
@@ -1,0 +1,14 @@
+name: husni-portfolio
+version: "3"
+
+services:
+  husni-portfolio:
+    image: "gcr.io/husni-release/husni-portfolio:0.3.5"
+    environment:
+        GOOGLE_APPLICATION_CREDENTIALS: /var/service_account.json
+    env_file:
+      - "../../.release.env"
+    ports:
+      - 8080:8080
+    volumes:
+      - ./../../release.service_account.json:/var/service_account.json


### PR DESCRIPTION
Tried to troubleshoot skewed navbar
<img width="590" height="162" alt="image" src="https://github.com/user-attachments/assets/96922450-27f2-4714-85b5-f22d0e817fb5" />
I tried to check the difference between pushed image and the latest version and failed to see any difference.

Turns out Cloudflare cache was still active (2h TTL). That cause the `styles.css` not updated. Tested on the GCP Cloud Run default domain, the skewed navbar is not existed. Case solved for now
<img width="617" height="120" alt="image" src="https://github.com/user-attachments/assets/a584af3a-bcd6-49ed-b001-1dbaadab6a97" />
